### PR TITLE
Add bearer token authorization to the bundle route

### DIFF
--- a/bundler/Cargo.lock
+++ b/bundler/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "sqlx",
  "tar",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -21,6 +21,7 @@ sqlx = { version = "0.7.3", features = [
 ] }
 tar = { version = "0.4.40" }
 tokio = { version = "1.35.0", features = ["macros", "rt-multi-thread"] }
+tower = { version = "0.4.13" }
 tower-http = { version = "0.5.0", features = ["trace"] }
 tracing = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.18" }

--- a/bundler/src/require_bearer.rs
+++ b/bundler/src/require_bearer.rs
@@ -1,0 +1,86 @@
+use axum::{
+    extract::Request,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use headers::{authorization::Bearer, Authorization, HeaderMapExt};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::{Layer, Service};
+
+/// A [`tower::Layer`] which checks for a correct Authorization Bearer token
+///
+/// Requests which do not have a valid token are sent a 401 Unauthorized response
+#[derive(Clone)]
+pub struct RequireBearerLayer {
+    /// The required token value
+    required_token: Option<String>,
+}
+
+impl RequireBearerLayer {
+    /// Creates the [`tower::Layer`] with a given required token
+    pub fn new(required_token: Option<String>) -> Self {
+        Self { required_token }
+    }
+}
+
+impl<S> Layer<S> for RequireBearerLayer {
+    type Service = RequireBearerMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequireBearerMiddleware {
+            inner,
+            required_token: self.required_token.clone(),
+        }
+    }
+}
+
+/// A [`tower::Service`] which checks for a correct Authorization Bearer token
+///
+/// Requests which do not have a valid token are sent a 401 Unauthorized response
+#[derive(Clone)]
+pub struct RequireBearerMiddleware<S> {
+    /// The wrapped [`Service`]
+    inner: S,
+    /// The required token value
+    required_token: Option<String>,
+}
+
+impl<S> Service<Request> for RequireBearerMiddleware<S>
+where
+    S: Service<Request, Response = Response> + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let valid_token = match (
+            self.required_token.as_ref(),
+            request.headers().typed_get::<Authorization<Bearer>>(),
+        ) {
+            (Some(required_token), Some(bearer_token)) => required_token == bearer_token.token(),
+            (Some(_), None) => false,
+            (None, _) => true,
+        };
+
+        let future = self.inner.call(request);
+
+        Box::pin(async move {
+            if valid_token {
+                Ok(future.await?)
+            } else {
+                Ok(StatusCode::UNAUTHORIZED.into_response())
+            }
+        })
+    }
+}

--- a/charts/bundler/templates/deployment.yaml
+++ b/charts/bundler/templates/deployment.yaml
@@ -38,6 +38,11 @@ spec:
                   key: {{ .Values.bundler.database.passwordSecret.key }}
             - name: BUNDLER_DATABASE_URL
               value: {{ include "bundler.databaseURL" . }}
+            - name: BUNDLER_REQUIRE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.bundler.requireTokenSecret.name }}
+                  key: {{ .Values.bundler.requireTokenSecret.key }}
             - name: BUNDLER_POLLING_INTERVAL
               value: {{ .Values.bundler.pollingInterval }}
           ports:

--- a/charts/bundler/templates/token-authorization.yaml
+++ b/charts/bundler/templates/token-authorization.yaml
@@ -1,0 +1,15 @@
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  creationTimestamp: null
+  name: token-authorization
+  namespace: authz-warehouse
+spec:
+  encryptedData:
+    bearer: AgCVPvjq7vUJgWZM2B/O15IX82Cm5+hq1xElZ9ViB5Bf4shheItYR11YeLieJqXL/iCAzuFBFQwEWZ0lVY67J0n1AdfsmOSLd0lp/4ep4WOST1evpXg2eEGNv2Ucbn2thMmOfrB2zQbc4Diqc6WFcL8M+S68ESHnWB9fJX8/MtAyF7ZxgeYXql7nPiPuebdSIPVSHoHMGrmoCOmDaw1+sc15XCdojlRLTozAyW+U7dNsdPLo7Nqf3kXbQyHFEDhfc9cP6LUuxn8SdiEe7WYrAMncf6rt6r+rM/3ZgfkY2uVV1xZoAUe1T7wIAUpz3CKQl0/qvGJWTexIpa1awraK/Dpj+RRKwrhvS5+ON96GD2IVYrM3BOoVMXWXFLBHjTtYto3YOhRLOa2ADZVmdbQbNMQ5ATo0QIWQPIXoaABrKrmmAwm41lvOEIU46koPsJAhx4pV6iYk+OJ6ffLhXfaSczPizUhG+3duE+aTm2B55/lGivfc+/MyzYv4iY616Lteo7T8p79XPbkiJjclCxTwqrt9EGvfF1/E/qvmMKJMS41Uy8JjWynKgwthtnV7Kh8GCjWlXk6hthzINXUUgMgUwycne/KYle8ufoMEn3w3ccp5F626ZfULtqGxytCxj1RATJYx1+prxsqf8xlWQMoenisH9VeFpDqqNrN2v9flCTL+EJ8FDNqV48MVVPOip8iub+3TLe6mPtQE5XBXT0vvNaXMQmdlGzvq6wSiNpBJTp+9tlOUx6M=
+  template:
+    metadata:
+      creationTimestamp: null
+      name: token-authorization
+      namespace: authz-warehouse
+

--- a/charts/bundler/values.yaml
+++ b/charts/bundler/values.yaml
@@ -16,6 +16,9 @@ bundler:
     passwordSecret:
       name: ispyb
       key: password
+  requireTokenSecret:
+    name: token-authorization
+    key: bearer
   pollingInterval: 60s
 
 serviceAccount:


### PR DESCRIPTION
Adds bearer token authorization to the `/bundle.tar.gz` endpoint. The required token can be configured via the CLI.
This should be replaced with an OAuth2 compliant proxy once we have support for device flow in our IdP. In the meantime this is no worse than the `ispyb_ro` account which is used for the underlying database access