### PR TITLE
Use proposal number in place of proposal ID

### DIFF
--- a/bundler/src/permissionables/proposals.rs
+++ b/bundler/src/permissionables/proposals.rs
@@ -10,11 +10,11 @@ impl Proposals {
     /// Fetches [`Proposals`] from ISPyB
     pub async fn fetch(ispyb_pool: &MySqlPool) -> Result<Self, sqlx::Error> {
         let proposal_rows = query_as!(
-            ProposalRow,
+            RawProposalRow,
             "
             SELECT
-                proposalId AS proposal_id,
-                login AS fed_id
+                login AS fed_id,
+                proposalNumber AS proposal_number
             FROM (
                     SELECT
                         DISTINCT proposalId,
@@ -23,6 +23,9 @@ impl Proposals {
                         ProposalHasPerson
                 ) AS UniqueProposalHasPerson
                 INNER JOIN Person USING (personId)
+                INNER JOIN Proposal USING (proposalId)
+            WHERE
+                Proposal.externalId IS NOT NULL
             "
         )
         .fetch_all(ispyb_pool)
@@ -35,21 +38,41 @@ impl Proposals {
 /// A row from ISPyB detailing the proposals a user is associated with
 struct ProposalRow {
     /// The FedID of the user
-    fed_id: Option<String>,
+    fed_id: String,
     /// The proposal number
-    proposal_id: u32,
+    proposal_number: u32,
 }
 
-impl FromIterator<ProposalRow> for Proposals {
-    fn from_iter<T: IntoIterator<Item = ProposalRow>>(iter: T) -> Self {
+#[allow(clippy::missing_docs_in_private_items)]
+struct RawProposalRow {
+    fed_id: Option<String>,
+    proposal_number: Option<String>,
+}
+
+impl TryFrom<RawProposalRow> for ProposalRow {
+    type Error = anyhow::Error;
+
+    fn try_from(value: RawProposalRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            fed_id: value.fed_id.ok_or(anyhow::anyhow!("FedId was NULL"))?,
+            proposal_number: value
+                .proposal_number
+                .ok_or(anyhow::anyhow!("Proposal number was NULL"))?
+                .parse()?,
+        })
+    }
+}
+
+impl FromIterator<RawProposalRow> for Proposals {
+    fn from_iter<T: IntoIterator<Item = RawProposalRow>>(iter: T) -> Self {
         let mut proposals = Self::default();
         for proposal_row in iter {
-            if let Some(fed_id) = proposal_row.fed_id {
+            if let Ok(proposal_row) = ProposalRow::try_from(proposal_row) {
                 proposals
                     .0
-                    .entry(fed_id)
+                    .entry(proposal_row.fed_id)
                     .or_default()
-                    .push(proposal_row.proposal_id)
+                    .push(proposal_row.proposal_number)
             }
         }
         proposals
@@ -73,14 +96,14 @@ mod tests {
         migrations = "tests/migrations",
         fixtures(
             path = "../../tests/fixtures",
-            scripts("proposal_membership", "persons")
+            scripts("proposal_membership", "persons", "proposals")
         )
     )]
     async fn fetch_some(ispyb_pool: MySqlPool) {
         let proposals = Proposals::fetch(&ispyb_pool).await.unwrap();
         let mut expected = BTreeMap::new();
-        expected.insert("foo".to_string(), BTreeSet::from([30, 31, 32]));
-        expected.insert("bar".to_string(), BTreeSet::from([30]));
+        expected.insert("foo".to_string(), BTreeSet::from([10030, 10031, 10032]));
+        expected.insert("bar".to_string(), BTreeSet::from([10030]));
         assert_eq!(
             expected,
             proposals

--- a/bundler/src/permissionables/sessions.rs
+++ b/bundler/src/permissionables/sessions.rs
@@ -10,19 +10,23 @@ impl Sessions {
     /// Fetches [`Sessions`] from ISPyB
     pub async fn fetch(ispyb_pool: &MySqlPool) -> Result<Self, sqlx::Error> {
         let session_rows = query_as!(
-            SessionRow,
+            RawSessionRow,
             "
             SELECT
                 login as fed_id,
-                proposalId as proposal_id,
+                proposalNumber AS proposal_number,
                 visit_number
-            FROM Session_has_Person
+            FROM
+                Session_has_Person
                 INNER JOIN BLSession USING (sessionId)
                 INNER JOIN Person USING (personId)
+                INNER JOIN Proposal USING (proposalId)
+            WHERE
+                Proposal.externalId IS NOT NULL
             UNION
             SELECT
                 login as fed_id,
-                BLSession.proposalId as proposal_id,
+                proposalNumber AS proposal_number,
                 visit_number
             FROM (
                     SELECT
@@ -33,6 +37,9 @@ impl Sessions {
                 ) AS UniqueProposalHasPerson
                 CROSS JOIN BLSession USING (proposalId)
                 INNER JOIN Person USING (personId)
+                INNER JOIN Proposal USING (proposalId)
+            WHERE
+                Proposal.externalId IS NOT NULL
             "
         )
         .fetch_all(ispyb_pool)
@@ -45,22 +52,45 @@ impl Sessions {
 /// A row from ISPyB detailing the sessions a user is associcated with
 struct SessionRow {
     /// The FedID of the user
-    fed_id: Option<String>,
+    fed_id: String,
     /// The proposal number of the visit
-    proposal_id: u32,
+    proposal_number: u32,
     /// The number of the visit within the proposal
+    visit_number: u32,
+}
+
+#[allow(clippy::missing_docs_in_private_items)]
+struct RawSessionRow {
+    fed_id: Option<String>,
+    proposal_number: Option<String>,
     visit_number: Option<u32>,
 }
 
-impl FromIterator<SessionRow> for Sessions {
-    fn from_iter<T: IntoIterator<Item = SessionRow>>(iter: T) -> Self {
+impl TryFrom<RawSessionRow> for SessionRow {
+    type Error = anyhow::Error;
+
+    fn try_from(value: RawSessionRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            fed_id: value.fed_id.ok_or(anyhow::anyhow!("FedId was NULL"))?,
+            proposal_number: value
+                .proposal_number
+                .ok_or(anyhow::anyhow!("Proposal number was NULL"))?
+                .parse()?,
+            visit_number: value.visit_number.unwrap_or_default(),
+        })
+    }
+}
+
+impl FromIterator<RawSessionRow> for Sessions {
+    fn from_iter<T: IntoIterator<Item = RawSessionRow>>(iter: T) -> Self {
         let mut sessions = Self::default();
         for session_row in iter {
-            if let Some(fed_id) = session_row.fed_id {
-                sessions.0.entry(fed_id).or_default().push((
-                    session_row.proposal_id,
-                    session_row.visit_number.unwrap_or_default(),
-                ));
+            if let Ok(session_row) = SessionRow::try_from(session_row) {
+                sessions
+                    .0
+                    .entry(session_row.fed_id)
+                    .or_default()
+                    .push((session_row.proposal_number, session_row.visit_number));
             }
         }
         sessions
@@ -84,14 +114,14 @@ mod tests {
         migrations = "tests/migrations",
         fixtures(
             path = "../../tests/fixtures",
-            scripts("session_membership", "beamline_sessions", "persons")
+            scripts("session_membership", "beamline_sessions", "persons", "proposals")
         )
     )]
     async fn fetch_direct(ispyb_pool: MySqlPool) {
         let sessions = Sessions::fetch(&ispyb_pool).await.unwrap();
         let mut expected = BTreeMap::new();
-        expected.insert("foo".to_string(), vec![(30, 10), (30, 11)]);
-        expected.insert("bar".to_string(), vec![(31, 10)]);
+        expected.insert("foo".to_string(), vec![(10030, 10), (10030, 11)]);
+        expected.insert("bar".to_string(), vec![(10031, 10)]);
         assert_eq!(
             expected,
             sessions
@@ -106,7 +136,7 @@ mod tests {
         migrations = "tests/migrations",
         fixtures(
             path = "../../tests/fixtures",
-            scripts("proposal_membership", "beamline_sessions", "persons")
+            scripts("proposal_membership", "beamline_sessions", "persons", "proposals")
         )
     )]
     async fn fetch_indirect(ispyb_pool: MySqlPool) {
@@ -114,11 +144,17 @@ mod tests {
         let mut expected = BTreeMap::new();
         expected.insert(
             "foo".to_string(),
-            BTreeSet::from([(30, 10), (30, 11), (30, 12), (31, 10), (31, 11)]),
+            BTreeSet::from([
+                (10030, 10),
+                (10030, 11),
+                (10030, 12),
+                (10031, 10),
+                (10031, 11),
+            ]),
         );
         expected.insert(
             "bar".to_string(),
-            BTreeSet::from([(30, 10), (30, 11), (30, 12)]),
+            BTreeSet::from([(10030, 10), (10030, 11), (10030, 12)]),
         );
         assert_eq!(
             expected,
@@ -138,7 +174,8 @@ mod tests {
                 "session_membership",
                 "proposal_membership",
                 "beamline_sessions",
-                "persons"
+                "persons",
+                "proposals"
             )
         )
     )]
@@ -147,11 +184,17 @@ mod tests {
         let mut expected = BTreeMap::new();
         expected.insert(
             "foo".to_string(),
-            BTreeSet::from([(30, 10), (30, 11), (30, 12), (31, 10), (31, 11)]),
+            BTreeSet::from([
+                (10030, 10),
+                (10030, 11),
+                (10030, 12),
+                (10031, 10),
+                (10031, 11),
+            ]),
         );
         expected.insert(
             "bar".to_string(),
-            BTreeSet::from([(30, 10), (30, 11), (30, 12), (31, 10)]),
+            BTreeSet::from([(10030, 10), (10030, 11), (10030, 12), (10031, 10)]),
         );
         assert_eq!(
             expected,

--- a/bundler/tests/fixtures/proposals.sql
+++ b/bundler/tests/fixtures/proposals.sql
@@ -1,0 +1,7 @@
+INSERT INTO
+    `Proposal` (
+        `proposalId`,
+        `proposalNumber`,
+        `externalId`
+    )
+VALUES (30, "10030", '272E'), (31, "10031", '272F'), (32, "10032", '2730')

--- a/bundler/tests/migrations/1_CopyISPyBTables.sql
+++ b/bundler/tests/migrations/1_CopyISPyBTables.sql
@@ -15,3 +15,5 @@ CREATE TABLE Permission LIKE ispyb_build.Permission;
 
 CREATE TABLE
     UserGroup_has_Permission LIKE ispyb_build.UserGroup_has_Permission;
+
+CREATE TABLE Proposal LIKE ispyb_build.Proposal


### PR DESCRIPTION
Resolves #31. @KarlLevik suggested that filtering out proposals where `externalId` is `NULL` would ensure that `proposalNumber` was unique - this is confirmed by a quick query