### PR TITLE
Publish OPA helm chart to `ghcr`

### DIFF
--- a/.github/workflows/opa-chart.yml
+++ b/.github/workflows/opa-chart.yml
@@ -1,0 +1,35 @@
+name: OPA Chart
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build_publish:
+    # Deduplicate jobs from pull requests and branch pushes within the same repo.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4.1.1
+
+      - name: Package Chart
+        run: helm package charts/opa
+
+      - name: Generate Image Name
+        run: echo IMAGE_REPOSITORY=oci://ghcr.io/$(echo "${{ github.repository }}-opa" | tr '[:upper:]' '[:lower:]' | tr '[_]' '[\-]') >> $GITHUB_ENV
+
+      - name: Log in to GitHub Docker Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Chart
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        run: helm push $(ls opa-*.tgz) ${{ env.IMAGE_REPOSITORY }}


### PR DESCRIPTION
Adds a CI job to publish the OPA helm chart to the GitHub container registry on tagged releases