### PR TITLE
Add bundler bearer token to default opa chart config

### DIFF
--- a/charts/opa/templates/deployment.yaml
+++ b/charts/opa/templates/deployment.yaml
@@ -39,6 +39,20 @@ spec:
             - --server
             - --config-file
             - /etc/opa-config/config.yaml
+          {{- if .Values.opa.envOverride }}
+          env:
+          {{- .Values.opa.envOverride | toYaml | nindent 12 }}
+          {{- else }}
+          env:
+            - name: BUNDLER_BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                    name: bundler
+                    key: bearer-token
+            {{- if .Values.opa.extraEnv }}
+            {{- .Values.opa.extraEnv | toYaml | nindent 12 }}
+            {{- end }}
+          {{- end }}
           volumeMounts:
             - name: opa-config
               mountPath: /etc/opa-config

--- a/charts/opa/templates/opa-config.yaml
+++ b/charts/opa/templates/opa-config.yaml
@@ -4,5 +4,29 @@ metadata:
   name: opa-config
 data:
   config.yaml: |
-    {{ toYaml .Values.opa.config | nindent 4 }}
+    {{- if .Values.opa.configOverride }}
+    {{ .Values.opa.configOverride | toYaml | nindent 6 }}
+    {{- else }}
+    services:
+      diamond-bundler:
+        url: https://authz.diamond.ac.uk
+      ghcr:
+        url: https://ghcr.io
+        type: oci
+      {{ .Values.opa.extraServices | toYaml | nindent 8 }}
+    bundles:
+      diamond-permissionables:
+        service: diamond-bundler
+        resource: bundle.tar.gz
+        polling:
+          min_delay_seconds: 10
+          max_delay_seconds: 60
+      diamond-policies:
+        service: ghcr
+        resource: ghcr.io/diamondlightsource/authz-policy:0.0.4
+        polling:
+          min_delay_seconds: 30
+          max_delay_seconds: 120
+      {{ .Values.opa.extraBundles | toYaml | nindent 8 }}
+    {{- end }}
 

--- a/charts/opa/templates/opa-config.yaml
+++ b/charts/opa/templates/opa-config.yaml
@@ -10,6 +10,9 @@ data:
     services:
       diamond-bundler:
         url: https://authz.diamond.ac.uk
+        credentials:
+          bearer:
+            token: ${BUNDLER_BEARER_TOKEN}
       ghcr:
         url: https://ghcr.io
         type: oci

--- a/charts/opa/values.yaml
+++ b/charts/opa/values.yaml
@@ -8,26 +8,9 @@ nameOverride: ""
 fullnameOverride: ""
 
 opa:
-  config:
-    services:
-      diamond-bundler:
-        url: https://authz.diamond.ac.uk
-      ghcr:
-        url: https://ghcr.io
-        type: oci
-    bundles:
-      diamond-permissionables:
-        service: diamond-bundler
-        resource: bundle.tar.gz
-        polling:
-          min_delay_seconds: 10
-          max_delay_seconds: 60
-      diamond-policies:
-        service: ghcr
-        resource: ghcr.io/diamondlightsource/authz-policy:0.0.4
-        polling:
-          min_delay_seconds: 30
-          max_delay_seconds: 120
+  configOverride: {}
+  extraServices: {}
+  extraBundles: {}
 
 serviceAccount:
   create: false

--- a/charts/opa/values.yaml
+++ b/charts/opa/values.yaml
@@ -11,6 +11,8 @@ opa:
   configOverride: {}
   extraServices: {}
   extraBundles: {}
+  envOverride: []
+  extraEnv: []
 
 serviceAccount:
   create: false


### PR DESCRIPTION
Has the default OPA deployment read in a secret with `name: bundler` and `key: bearer-token` as `BUNDLER_BEARER_TOKEN`, which is referenced by the OPA config as the bearer token to send to the `diamond-bundler` service