### PR TITLE
Structure bundle for ABAC

### DIFF
--- a/bundler/Cargo.lock
+++ b/bundler/Cargo.lock
@@ -321,6 +321,7 @@ dependencies = [
  "built",
  "clap",
  "clio",
+ "derive_more",
  "dotenvy",
  "flate2",
  "headers",
@@ -438,6 +439,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +520,19 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1649,6 +1669,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,6 +1780,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"

--- a/bundler/Cargo.toml
+++ b/bundler/Cargo.toml
@@ -9,6 +9,7 @@ axum = { version = "0.7.3" }
 axum-extra = { version = "0.9.1", features = ["typed-header"] }
 clap = { version = "4.4.13", features = ["derive", "env"] }
 clio = { version = "0.3.5", features = ["clap-parse"] }
+derive_more = { version = "0.99.17" }
 dotenvy = { version = "0.15.7" }
 flate2 = { version = "1.0.28" }
 headers = { version = "0.4.0" }

--- a/bundler/src/permissionables/beamlines.rs
+++ b/bundler/src/permissionables/beamlines.rs
@@ -1,0 +1,115 @@
+use derive_more::{Deref, DerefMut};
+use schemars::JsonSchema;
+use serde::Serialize;
+use sqlx::{query_as, MySqlPool};
+use std::collections::BTreeMap;
+use tracing::instrument;
+
+/// A mapping of beamlines to their various attributes
+#[derive(Debug, Default, Deref, DerefMut, PartialEq, Eq, Hash, Serialize, JsonSchema)]
+pub struct Beamlines(BTreeMap<String, Beamline>);
+
+impl Beamlines {
+    /// Fetches [`Beamlines`] from ISPyB
+    #[instrument(name = "fetch_beamlines")]
+    pub async fn fetch(ispyb_pool: &MySqlPool) -> Result<Self, sqlx::Error> {
+        let session_rows = query_as!(
+            RawBeamlineRow,
+            "
+            SELECT
+                beamLineName as beamline,
+                sessionId as session_id
+            FROM
+                BLSession
+            "
+        )
+        .fetch_all(ispyb_pool)
+        .await?;
+
+        Ok(session_rows.into_iter().collect())
+    }
+}
+
+/// The various attributes of a beamline
+#[derive(Debug, Default, PartialEq, Eq, Hash, Serialize, JsonSchema)]
+pub struct Beamline {
+    /// The sessions which occured on this beamline
+    sessions: Vec<u32>,
+}
+
+/// A row from ISPyB detailing the sessions on a beamline
+struct BeamlineRow {
+    /// The beamline name
+    beamline: String,
+    /// An opaque identifier of the session
+    session_id: u32,
+}
+
+#[allow(clippy::missing_docs_in_private_items)]
+struct RawBeamlineRow {
+    beamline: Option<String>,
+    session_id: u32,
+}
+
+impl TryFrom<RawBeamlineRow> for BeamlineRow {
+    type Error = anyhow::Error;
+
+    fn try_from(value: RawBeamlineRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            beamline: value
+                .beamline
+                .ok_or(anyhow::anyhow!("Beamline Name was NULL"))?
+                .parse()?,
+            session_id: value.session_id,
+        })
+    }
+}
+
+impl FromIterator<RawBeamlineRow> for Beamlines {
+    fn from_iter<T: IntoIterator<Item = RawBeamlineRow>>(iter: T) -> Self {
+        let mut beamlines = Self::default();
+        for beamline_row in iter {
+            if let Ok(beamline) = BeamlineRow::try_from(beamline_row) {
+                beamlines
+                    .entry(beamline.beamline)
+                    .or_default()
+                    .sessions
+                    .push(beamline.session_id)
+            }
+        }
+        beamlines
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Beamline, Beamlines};
+    use sqlx::MySqlPool;
+    use std::collections::BTreeMap;
+
+    #[sqlx::test(migrations = "tests/migrations")]
+    async fn fetch_empty(ispyb_pool: MySqlPool) {
+        let beamlines = Beamlines::fetch(&ispyb_pool).await.unwrap();
+        let expected = Beamlines(BTreeMap::new());
+        assert_eq!(expected, beamlines);
+    }
+
+    #[sqlx::test(
+        migrations = "tests/migrations",
+        fixtures(path = "../../tests/fixtures", scripts("beamline_sessions"))
+    )]
+    async fn fetch_some(ispyb_pool: MySqlPool) {
+        let beamlines = Beamlines::fetch(&ispyb_pool).await.unwrap();
+        let mut expected = BTreeMap::new();
+        expected.insert("i12".to_string(), Beamline { sessions: vec![40] });
+        expected.insert(
+            "i22".to_string(),
+            Beamline {
+                sessions: vec![41, 44],
+            },
+        );
+        expected.insert("b13".to_string(), Beamline { sessions: vec![42] });
+        expected.insert("p99".to_string(), Beamline { sessions: vec![43] });
+        assert_eq!(expected, beamlines.0);
+    }
+}

--- a/bundler/src/permissionables/mod.rs
+++ b/bundler/src/permissionables/mod.rs
@@ -1,2 +1,4 @@
+/// A mapping of sessions to their attributes
+pub mod sessions;
 /// A mapping of subjects to their attributes
 pub mod subjects;

--- a/bundler/src/permissionables/mod.rs
+++ b/bundler/src/permissionables/mod.rs
@@ -1,3 +1,5 @@
+/// A mapping of proposals to their attributes
+pub mod proposals;
 /// A mapping of sessions to their attributes
 pub mod sessions;
 /// A mapping of subjects to their attributes

--- a/bundler/src/permissionables/mod.rs
+++ b/bundler/src/permissionables/mod.rs
@@ -1,3 +1,5 @@
+/// A mapping of beamlines to their attributes
+pub mod beamlines;
 /// A mapping of proposals to their attributes
 pub mod proposals;
 /// A mapping of sessions to their attributes

--- a/bundler/src/permissionables/mod.rs
+++ b/bundler/src/permissionables/mod.rs
@@ -1,6 +1,2 @@
-/// A mapping of users to their permissions, via groups
-pub mod permissions;
-/// A mapping of users to their proposals
-pub mod proposals;
-/// A mapping of users to their sessions, possibly via proposals
-pub mod sessions;
+/// A mapping of subjects to their attributes
+pub mod subjects;

--- a/bundler/src/permissionables/proposals.rs
+++ b/bundler/src/permissionables/proposals.rs
@@ -1,0 +1,124 @@
+use derive_more::{Deref, DerefMut};
+use schemars::JsonSchema;
+use serde::Serialize;
+use sqlx::{query_as, MySqlPool};
+use std::collections::BTreeMap;
+use tracing::instrument;
+
+/// A mapping of proposals to their various attributes
+#[derive(Debug, Default, Deref, DerefMut, PartialEq, Eq, Hash, Serialize, JsonSchema)]
+pub struct Proposals(BTreeMap<u32, Proposal>);
+
+impl Proposals {
+    /// Fetches [`Proposals`] from ISPyB
+    #[instrument(name = "fetch_proposals")]
+    pub async fn fetch(ispyb_pool: &MySqlPool) -> Result<Self, sqlx::Error> {
+        let proposal_rows = query_as!(
+            RawProposalRow,
+            "
+            SELECT
+                proposalNumber as proposal_number,
+                sessionId as session_id
+            FROM
+                BLSession
+                JOIN Proposal USING (proposalId)
+            WHERE
+                Proposal.externalId IS NOT NULL
+            "
+        )
+        .fetch_all(ispyb_pool)
+        .await?;
+
+        Ok(proposal_rows.into_iter().collect())
+    }
+}
+
+/// The various attributes of a proposal
+#[derive(Debug, Default, PartialEq, Eq, Hash, Serialize, JsonSchema)]
+pub struct Proposal {
+    /// The sessions which took place within the proposal
+    sessions: Vec<u32>,
+}
+
+/// A row from ISPyB detailing the sessions in a proposal
+struct ProposalRow {
+    /// The proposal number
+    proposal_number: u32,
+    /// An opaque identifier of the session
+    session_id: u32,
+}
+
+#[allow(clippy::missing_docs_in_private_items)]
+struct RawProposalRow {
+    proposal_number: Option<String>,
+    session_id: u32,
+}
+
+impl TryFrom<RawProposalRow> for ProposalRow {
+    type Error = anyhow::Error;
+
+    fn try_from(value: RawProposalRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            proposal_number: value
+                .proposal_number
+                .ok_or(anyhow::anyhow!("Proposal Number was NULL"))?
+                .parse()?,
+            session_id: value.session_id,
+        })
+    }
+}
+
+impl FromIterator<RawProposalRow> for Proposals {
+    fn from_iter<T: IntoIterator<Item = RawProposalRow>>(iter: T) -> Self {
+        let mut proposals = Self::default();
+        for proposal_row in iter {
+            if let Ok(proposal_row) = ProposalRow::try_from(proposal_row) {
+                proposals
+                    .entry(proposal_row.proposal_number)
+                    .or_default()
+                    .sessions
+                    .push(proposal_row.session_id)
+            }
+        }
+        proposals
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Proposal, Proposals};
+    use sqlx::MySqlPool;
+    use std::collections::BTreeMap;
+
+    #[sqlx::test(migrations = "tests/migrations")]
+    async fn fetch_empty(ispyb_pool: MySqlPool) {
+        let proposals = Proposals::fetch(&ispyb_pool).await.unwrap();
+        let expected = Proposals(BTreeMap::new());
+        assert_eq!(expected, proposals);
+    }
+
+    #[sqlx::test(
+        migrations = "tests/migrations",
+        fixtures(
+            path = "../../tests/fixtures",
+            scripts("beamline_sessions", "proposals")
+        )
+    )]
+    async fn fetch_some(ispyb_pool: MySqlPool) {
+        let beamlines = Proposals::fetch(&ispyb_pool).await.unwrap();
+        let mut expected = BTreeMap::new();
+        expected.insert(
+            10030,
+            Proposal {
+                sessions: vec![40, 41, 42],
+            },
+        );
+        expected.insert(
+            10031,
+            Proposal {
+                sessions: vec![43, 44],
+            },
+        );
+        assert_eq!(expected, beamlines.0);
+    }
+}

--- a/bundler/src/permissionables/sessions.rs
+++ b/bundler/src/permissionables/sessions.rs
@@ -1,0 +1,167 @@
+use derive_more::{Deref, DerefMut};
+use schemars::JsonSchema;
+use serde::Serialize;
+use sqlx::{query_as, MySqlPool};
+use std::collections::BTreeMap;
+use tracing::instrument;
+
+/// A mapping of sessions to their various attributes
+#[derive(Debug, Default, Deref, DerefMut, PartialEq, Eq, Hash, Serialize, JsonSchema)]
+pub struct Sessions(BTreeMap<u32, Session>);
+
+impl Sessions {
+    /// Fetches [`Sessions`] from ISPyB
+    #[instrument(name = "fetch_sessions")]
+    pub async fn fetch(ispyb_pool: &MySqlPool) -> Result<Self, sqlx::Error> {
+        let session_rows = query_as!(
+            RawSessionRow,
+            "
+            SELECT
+                sessionId as session_id,
+                proposalNumber as proposal_number,
+                visit_number,
+                beamLineName as beamline
+            FROM
+                BLSession
+                JOIN Proposal USING (proposalId)
+            "
+        )
+        .fetch_all(ispyb_pool)
+        .await?;
+
+        Ok(session_rows.into_iter().collect())
+    }
+}
+
+/// The various attributes of a session
+#[derive(Debug, Default, PartialEq, Eq, Hash, Serialize, JsonSchema)]
+pub struct Session {
+    /// The number of the proposal this session belongs to
+    proposal_number: u32,
+    /// The number of the visit within the proposal this session belongs to
+    visit_number: u32,
+    /// The beamline the session took place on
+    beamline: String,
+}
+
+/// A row from ISPyB detailing the beamline a session took place on
+struct SessionRow {
+    /// An opaque identifier of the session
+    session_id: u32,
+    /// The proposal number of the visit
+    proposal_number: u32,
+    /// The number of the visit within the proposal
+    visit_number: u32,
+    /// The beamline the session took place on
+    beamline: String,
+}
+
+#[allow(clippy::missing_docs_in_private_items)]
+struct RawSessionRow {
+    session_id: u32,
+    proposal_number: Option<String>,
+    visit_number: Option<u32>,
+    beamline: Option<String>,
+}
+
+impl TryFrom<RawSessionRow> for SessionRow {
+    type Error = anyhow::Error;
+
+    fn try_from(value: RawSessionRow) -> Result<Self, Self::Error> {
+        Ok(Self {
+            session_id: value.session_id,
+            proposal_number: value
+                .proposal_number
+                .ok_or(anyhow::anyhow!("Proposal number was NULL"))?
+                .parse()?,
+            visit_number: value.visit_number.unwrap_or_default(),
+            beamline: value.beamline.ok_or(anyhow::anyhow!("Beamline was NULL"))?,
+        })
+    }
+}
+
+impl FromIterator<RawSessionRow> for Sessions {
+    fn from_iter<T: IntoIterator<Item = RawSessionRow>>(iter: T) -> Self {
+        let mut sessions = Self::default();
+        for session_row in iter {
+            if let Ok(session_row) = SessionRow::try_from(session_row) {
+                sessions.insert(
+                    session_row.session_id,
+                    Session {
+                        proposal_number: session_row.proposal_number,
+                        visit_number: session_row.visit_number,
+                        beamline: session_row.beamline,
+                    },
+                );
+            }
+        }
+        sessions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Session, Sessions};
+    use sqlx::MySqlPool;
+    use std::collections::BTreeMap;
+
+    #[sqlx::test(migrations = "tests/migrations")]
+    async fn fetch_empty(ispyb_pool: MySqlPool) {
+        let sessions = Sessions::fetch(&ispyb_pool).await.unwrap();
+        let expected = Sessions(BTreeMap::new());
+        assert_eq!(expected, sessions);
+    }
+
+    #[sqlx::test(
+        migrations = "tests/migrations",
+        fixtures(
+            path = "../../tests/fixtures",
+            scripts("beamline_sessions", "proposals")
+        )
+    )]
+    async fn fetch_some(ispyb_pool: MySqlPool) {
+        let sessions = Sessions::fetch(&ispyb_pool).await.unwrap();
+        let mut expected = BTreeMap::new();
+        expected.insert(
+            40,
+            Session {
+                proposal_number: 10030,
+                visit_number: 10,
+                beamline: "i12".to_string(),
+            },
+        );
+        expected.insert(
+            41,
+            Session {
+                proposal_number: 10030,
+                visit_number: 11,
+                beamline: "i22".to_string(),
+            },
+        );
+        expected.insert(
+            42,
+            Session {
+                proposal_number: 10030,
+                visit_number: 12,
+                beamline: "b13".to_string(),
+            },
+        );
+        expected.insert(
+            43,
+            Session {
+                proposal_number: 10031,
+                visit_number: 10,
+                beamline: "p99".to_string(),
+            },
+        );
+        expected.insert(
+            44,
+            Session {
+                proposal_number: 10031,
+                visit_number: 11,
+                beamline: "i22".to_string(),
+            },
+        );
+        assert_eq!(expected, sessions.0);
+    }
+}

--- a/bundler/src/permissionables/subjects/mod.rs
+++ b/bundler/src/permissionables/subjects/mod.rs
@@ -27,7 +27,7 @@ pub struct Subject {
     /// The proposals the subject is associated with
     proposals: Vec<u32>,
     /// The sessions the subject is associated with
-    sessions: Vec<(u32, u32)>,
+    sessions: Vec<u32>,
 }
 
 impl Subjects {

--- a/bundler/src/permissionables/subjects/mod.rs
+++ b/bundler/src/permissionables/subjects/mod.rs
@@ -1,0 +1,60 @@
+/// A mapping of subjects to their permissions, via roles
+mod permissions;
+/// A mapping of subjects to their proposals
+mod proposals;
+/// A mapping of subjects to their sessions, possibly via proposals
+mod sessions;
+
+use self::{
+    permissions::SubjectPermissions, proposals::SubjectProposals, sessions::SubjectSessions,
+};
+use derive_more::{Deref, DerefMut};
+use schemars::JsonSchema;
+use serde::Serialize;
+use sqlx::MySqlPool;
+use std::collections::{BTreeMap, HashSet};
+use tracing::instrument;
+
+/// A mapping of subjects to their various attributes
+#[derive(Debug, Default, Deref, DerefMut, PartialEq, Eq, Hash, Serialize, JsonSchema)]
+pub struct Subjects(BTreeMap<String, Subject>);
+
+/// The various attributes of a subject
+#[derive(Debug, Default, PartialEq, Eq, Hash, Serialize, JsonSchema)]
+pub struct Subject {
+    /// The permissions given to a subject
+    permissions: Vec<String>,
+    /// The proposals the subject is associated with
+    proposals: Vec<u32>,
+    /// The sessions the subject is associated with
+    sessions: Vec<(u32, u32)>,
+}
+
+impl Subjects {
+    #[instrument(name = "fetch_subjects")]
+    pub async fn fetch(ispyb_pool: &MySqlPool) -> Result<Self, sqlx::Error> {
+        let mut permissions = SubjectPermissions::fetch(ispyb_pool).await?;
+        let mut proposals = SubjectProposals::fetch(ispyb_pool).await?;
+        let mut sessions = SubjectSessions::fetch(ispyb_pool).await?;
+
+        let mut subjects = Self::default();
+        for subject in permissions
+            .keys()
+            .chain(proposals.keys())
+            .chain(sessions.keys())
+            .cloned()
+            .collect::<HashSet<_>>()
+        {
+            subjects.insert(
+                subject.to_owned(),
+                Subject {
+                    permissions: permissions.remove(&subject).clone().unwrap_or_default(),
+                    proposals: proposals.remove(&subject).unwrap_or_default(),
+                    sessions: sessions.remove(&subject).unwrap_or_default(),
+                },
+            );
+        }
+
+        Ok(subjects)
+    }
+}

--- a/bundler/src/permissionables/subjects/permissions.rs
+++ b/bundler/src/permissionables/subjects/permissions.rs
@@ -11,7 +11,7 @@ pub struct SubjectPermissions(BTreeMap<String, Vec<String>>);
 
 impl SubjectPermissions {
     /// Fetches [`SubjectAttributes`] from ISPyB
-    #[instrument(name = "fetch_permissions")]
+    #[instrument(name = "fetch_subject_permissions")]
     pub async fn fetch(ispyb_pool: &MySqlPool) -> Result<Self, sqlx::Error> {
         let permisions_rows = query_as!(
             PermissionRow,

--- a/bundler/src/permissionables/subjects/permissions.rs
+++ b/bundler/src/permissionables/subjects/permissions.rs
@@ -1,22 +1,23 @@
+use derive_more::{Deref, DerefMut};
 use schemars::JsonSchema;
 use serde::Serialize;
 use sqlx::{query_as, MySqlPool};
 use std::collections::BTreeMap;
 use tracing::instrument;
 
-/// A mapping of users to their permissions via groups
-#[derive(Debug, Default, PartialEq, Eq, Hash, Serialize, JsonSchema)]
-pub struct Permissions(BTreeMap<String, Vec<String>>);
+/// A mapping of subjects to their permissions via roles
+#[derive(Debug, Default, Deref, DerefMut, PartialEq, Eq, Hash, Serialize, JsonSchema)]
+pub struct SubjectPermissions(BTreeMap<String, Vec<String>>);
 
-impl Permissions {
-    /// Fetches [`Permissions`] from ISPyB
+impl SubjectPermissions {
+    /// Fetches [`SubjectAttributes`] from ISPyB
     #[instrument(name = "fetch_permissions")]
     pub async fn fetch(ispyb_pool: &MySqlPool) -> Result<Self, sqlx::Error> {
         let permisions_rows = query_as!(
             PermissionRow,
             "
             SELECT
-                login as fed_id,
+                login as subject,
                 type as permission
             FROM Person
                 JOIN UserGroup_has_Person ON Person.personId = UserGroup_has_Person.personId
@@ -32,21 +33,20 @@ impl Permissions {
     }
 }
 
-/// A row from ISPyB detailing the permissions a user has been given
+/// A row from ISPyB detailing the attributes a subject has been given
 struct PermissionRow {
-    /// The FedID of the user
-    fed_id: Option<String>,
-    /// The permission the user has been given
+    /// The unique identifier of the subject
+    subject: Option<String>,
+    /// The attribute the subject has been given
     permission: String,
 }
 
-impl FromIterator<PermissionRow> for Permissions {
+impl FromIterator<PermissionRow> for SubjectPermissions {
     fn from_iter<T: IntoIterator<Item = PermissionRow>>(iter: T) -> Self {
         let mut permissions = Self::default();
         for permission_row in iter {
-            if let Some(fed_id) = permission_row.fed_id {
+            if let Some(fed_id) = permission_row.subject {
                 permissions
-                    .0
                     .entry(fed_id)
                     .or_default()
                     .push(permission_row.permission)
@@ -58,21 +58,21 @@ impl FromIterator<PermissionRow> for Permissions {
 
 #[cfg(test)]
 mod tests {
-    use super::Permissions;
+    use super::SubjectPermissions;
     use sqlx::MySqlPool;
     use std::collections::{BTreeMap, BTreeSet};
 
     #[sqlx::test(migrations = "tests/migrations")]
     async fn fetch_empty(ispyb_pool: MySqlPool) {
-        let permissions = Permissions::fetch(&ispyb_pool).await.unwrap();
-        let expected = Permissions::default();
+        let permissions = SubjectPermissions::fetch(&ispyb_pool).await.unwrap();
+        let expected = SubjectPermissions::default();
         assert_eq!(expected, permissions)
     }
 
     #[sqlx::test(
         migrations = "tests/migrations",
         fixtures(
-            path = "../../tests/fixtures",
+            path = "../../../tests/fixtures",
             scripts(
                 "persons",
                 "user_groups",
@@ -83,7 +83,7 @@ mod tests {
         )
     )]
     async fn fetch_some(ispyb_pool: MySqlPool) {
-        let permissions = Permissions::fetch(&ispyb_pool).await.unwrap();
+        let permissions = SubjectPermissions::fetch(&ispyb_pool).await.unwrap();
         let mut expected = BTreeMap::new();
         expected.insert(
             "foo".to_string(),

--- a/bundler/src/permissionables/subjects/proposals.rs
+++ b/bundler/src/permissionables/subjects/proposals.rs
@@ -1,3 +1,4 @@
+use derive_more::{Deref, DerefMut};
 use schemars::JsonSchema;
 use serde::Serialize;
 use sqlx::{query_as, MySqlPool};
@@ -5,10 +6,10 @@ use std::collections::BTreeMap;
 use tracing::instrument;
 
 /// A mapping of users to their proposals
-#[derive(Debug, Default, PartialEq, Eq, Hash, Serialize, JsonSchema)]
-pub struct Proposals(BTreeMap<String, Vec<u32>>);
+#[derive(Debug, Default, Deref, DerefMut, PartialEq, Eq, Hash, Serialize, JsonSchema)]
+pub struct SubjectProposals(BTreeMap<String, Vec<u32>>);
 
-impl Proposals {
+impl SubjectProposals {
     /// Fetches [`Proposals`] from ISPyB
     #[instrument(name = "fetch_proposals")]
     pub async fn fetch(ispyb_pool: &MySqlPool) -> Result<Self, sqlx::Error> {
@@ -16,15 +17,9 @@ impl Proposals {
             RawProposalRow,
             "
             SELECT
-                login AS fed_id,
+                login AS subject,
                 proposalNumber AS proposal_number
-            FROM (
-                    SELECT
-                        DISTINCT proposalId,
-                        personId
-                    FROM
-                        ProposalHasPerson
-                ) AS UniqueProposalHasPerson
+            FROM ProposalHasPerson
                 INNER JOIN Person USING (personId)
                 INNER JOIN Proposal USING (proposalId)
             WHERE
@@ -38,17 +33,17 @@ impl Proposals {
     }
 }
 
-/// A row from ISPyB detailing the proposals a user is associated with
+/// A row from ISPyB detailing the proposals a subject is associated with
 struct ProposalRow {
-    /// The FedID of the user
-    fed_id: String,
+    /// The unique identifier of the subject
+    subject: String,
     /// The proposal number
     proposal_number: u32,
 }
 
 #[allow(clippy::missing_docs_in_private_items)]
 struct RawProposalRow {
-    fed_id: Option<String>,
+    subject: Option<String>,
     proposal_number: Option<String>,
 }
 
@@ -57,7 +52,7 @@ impl TryFrom<RawProposalRow> for ProposalRow {
 
     fn try_from(value: RawProposalRow) -> Result<Self, Self::Error> {
         Ok(Self {
-            fed_id: value.fed_id.ok_or(anyhow::anyhow!("FedId was NULL"))?,
+            subject: value.subject.ok_or(anyhow::anyhow!("FedId was NULL"))?,
             proposal_number: value
                 .proposal_number
                 .ok_or(anyhow::anyhow!("Proposal number was NULL"))?
@@ -66,14 +61,13 @@ impl TryFrom<RawProposalRow> for ProposalRow {
     }
 }
 
-impl FromIterator<RawProposalRow> for Proposals {
+impl FromIterator<RawProposalRow> for SubjectProposals {
     fn from_iter<T: IntoIterator<Item = RawProposalRow>>(iter: T) -> Self {
         let mut proposals = Self::default();
         for proposal_row in iter {
             if let Ok(proposal_row) = ProposalRow::try_from(proposal_row) {
                 proposals
-                    .0
-                    .entry(proposal_row.fed_id)
+                    .entry(proposal_row.subject)
                     .or_default()
                     .push(proposal_row.proposal_number)
             }
@@ -84,26 +78,26 @@ impl FromIterator<RawProposalRow> for Proposals {
 
 #[cfg(test)]
 mod tests {
-    use super::Proposals;
+    use super::SubjectProposals;
     use sqlx::MySqlPool;
     use std::collections::{BTreeMap, BTreeSet};
 
     #[sqlx::test(migrations = "tests/migrations")]
     async fn fetch_empty(ispyb_pool: MySqlPool) {
-        let proposals = Proposals::fetch(&ispyb_pool).await.unwrap();
-        let expected = Proposals(BTreeMap::new());
+        let proposals = SubjectProposals::fetch(&ispyb_pool).await.unwrap();
+        let expected = SubjectProposals(BTreeMap::new());
         assert_eq!(expected, proposals);
     }
 
     #[sqlx::test(
         migrations = "tests/migrations",
         fixtures(
-            path = "../../tests/fixtures",
+            path = "../../../tests/fixtures",
             scripts("proposal_membership", "persons", "proposals")
         )
     )]
     async fn fetch_some(ispyb_pool: MySqlPool) {
-        let proposals = Proposals::fetch(&ispyb_pool).await.unwrap();
+        let proposals = SubjectProposals::fetch(&ispyb_pool).await.unwrap();
         let mut expected = BTreeMap::new();
         expected.insert("foo".to_string(), BTreeSet::from([10030, 10031, 10032]));
         expected.insert("bar".to_string(), BTreeSet::from([10030]));

--- a/bundler/src/permissionables/subjects/proposals.rs
+++ b/bundler/src/permissionables/subjects/proposals.rs
@@ -11,7 +11,7 @@ pub struct SubjectProposals(BTreeMap<String, Vec<u32>>);
 
 impl SubjectProposals {
     /// Fetches [`Proposals`] from ISPyB
-    #[instrument(name = "fetch_proposals")]
+    #[instrument(name = "fetch_subject_proposals")]
     pub async fn fetch(ispyb_pool: &MySqlPool) -> Result<Self, sqlx::Error> {
         let proposal_rows = query_as!(
             RawProposalRow,

--- a/bundler/tests/fixtures/beamline_sessions.sql
+++ b/bundler/tests/fixtures/beamline_sessions.sql
@@ -2,6 +2,7 @@ INSERT INTO
     `BLSession` (
         `sessionId`,
         `proposalId`,
-        `visit_number`
+        `visit_number`,
+        `beamLineName`
     )
-VALUES (40, 30, 10), (41, 30, 11), (42, 30, 12), (43, 31, 10), (44, 31, 11);
+VALUES (40, 30, 10, "i12"), (41, 30, 11, "i22"), (42, 30, 12, "b13"), (43, 31, 10, "p99"), (44, 31, 11, "i22");


### PR DESCRIPTION
Restructured the bundle to contain four primary components:
- Subjects: A mapping of subject ID to an object containing:
  - A list of their permissions
  - A list of their proposals
  - A list of their sessions
- Sessions: A mapping of sessions to an object containing:
  - Proposal number
  - Visit number
  - Beamline name
- Proposals: A mapping of proposal number to an object containing:
  - A list of sessions
- Beamlines: A mapping of beamline name to an object containing:
  - A list of sessions