### PR TITLE
Flatten OPA Helm values

### DIFF
--- a/charts/opa/Chart.yaml
+++ b/charts/opa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opa
 description: An OPA deployment to run alongside applications requiring authorization
 type: application
-version: 0.2.2
+version: 0.3.0
 appVersion: 0.59.0
 maintainers:
   - name: garryod

--- a/charts/opa/templates/_helpers.tpl
+++ b/charts/opa/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "opa.name" -}}
-{{- printf "%s-opa" .Chart.Name | default .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
@@ -14,7 +14,7 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := printf "%s-opa" .Chart.Name | default .Values.nameOverride }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -81,7 +81,7 @@ Create the tag to be used to pull the chart
 Determine the query port to be used
 */}}
 {{- define "opa.queryPort" -}}
-{{- if .Values.opa.portOverride }}
+{{- if .Values.portOverride }}
 {{- .Values.image.portOverride }}
 {{- else }}
 {{- if .Values.image.envoy }}

--- a/charts/opa/templates/deployment.yaml
+++ b/charts/opa/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ .Values.opa.config | toJson | sha256sum }}
+        checksum/config: {{ .Values.config | toJson | sha256sum }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -42,25 +42,25 @@ spec:
             - --config-file
             - /etc/opa-config/config.yaml
             - --log-level
-            - {{ .Values.opa.logLevel }}
-          {{- if .Values.opa.envOverride }}
+            - {{ .Values.logLevel }}
+          {{- if .Values.envOverride }}
           env:
-          {{- .Values.opa.envOverride | toYaml | nindent 12 }}
-          {{- else if or .Values.opa.orgData.bundlerSecret .Values.opa.extraEnv }}
+          {{- .Values.envOverride | toYaml | nindent 12 }}
+          {{- else if or .Values.orgData.bundlerSecret .Values.extraEnv }}
           env:
-            {{- if and .Values.opa.orgData.enabled .Values.opa.orgData.bundlerSecret }}
+            {{- if and .Values.orgData.enabled .Values.orgData.bundlerSecret }}
             - name: BUNDLER_BEARER_TOKEN
               valueFrom:
                 secretKeyRef:
-                    name: {{ tpl .Values.opa.orgData.bundlerSecret.name . }}
-                    key: {{ .Values.opa.orgData.bundlerSecret.key }}
+                    name: {{ tpl .Values.orgData.bundlerSecret.name . }}
+                    key: {{ .Values.orgData.bundlerSecret.key }}
             {{- end -}}
-            {{- if and .Values.opa.orgPolicy.enabled .Values.opa.orgPolicy.userinfoEndpoint }}
+            {{- if and .Values.orgPolicy.enabled .Values.orgPolicy.userinfoEndpoint }}
             - name: USERINFO_ENDPOINT
-              value: {{ .Values.opa.orgPolicy.userinfoEndpoint }}
+              value: {{ .Values.orgPolicy.userinfoEndpoint }}
             {{- end }}
-            {{- if .Values.opa.extraEnv }}
-              {{- .Values.opa.extraEnv | toYaml | nindent 12 }}
+            {{- if .Values.extraEnv }}
+              {{- .Values.extraEnv | toYaml | nindent 12 }}
             {{- end }}
           {{- end }}
           volumeMounts:

--- a/charts/opa/templates/opa-config.yaml
+++ b/charts/opa/templates/opa-config.yaml
@@ -4,8 +4,8 @@ metadata:
   name: opa-config
 data:
   config.yaml: |
-    {{- if .Values.opa.configOverride }}
-    {{- .Values.opa.configOverride | toYaml | nindent 4 }}
+    {{- if .Values.configOverride }}
+    {{- .Values.configOverride | toYaml | nindent 4 }}
     {{- else }}
     services:
       diamond-bundler:
@@ -16,12 +16,12 @@ data:
       ghcr:
         url: https://ghcr.io
         type: oci
-      {{- if .Values.opa.extraServices }}
-      {{- .Values.opa.extraServices | toYaml | nindent 6 }}
+      {{- if .Values.extraServices }}
+      {{- .Values.extraServices | toYaml | nindent 6 }}
       {{- end }}
-    {{- if or .Values.opa.orgData.enabled .Values.opa.orgPolicy.enabled .Values.opa.extraBundles }}
+    {{- if or .Values.orgData.enabled .Values.orgPolicy.enabled .Values.extraBundles }}
     bundles:
-      {{- if .Values.opa.orgData.enabled }}
+      {{- if .Values.orgData.enabled }}
       diamond-permissionables:
         service: diamond-bundler
         resource: bundle.tar.gz
@@ -29,7 +29,7 @@ data:
           min_delay_seconds: 10
           max_delay_seconds: 60
       {{- end }}
-      {{- if .Values.opa.orgPolicy.enabled }}
+      {{- if .Values.orgPolicy.enabled }}
       diamond-policies:
         service: ghcr
         resource: ghcr.io/diamondlightsource/authz-policy:0.0.9
@@ -37,11 +37,11 @@ data:
           min_delay_seconds: 30
           max_delay_seconds: 120
       {{- end }}
-      {{- if .Values.opa.extraBundles }}
-      {{- .Values.opa.extraBundles | toYaml | nindent 6 }}
+      {{- if .Values.extraBundles }}
+      {{- .Values.extraBundles | toYaml | nindent 6 }}
       {{- end }}
     {{- end }}
-    {{- if .Values.opa.extraConfig }}
-    {{- .Values.opa.extraConfig | toYaml | nindent 4 }}
+    {{- if .Values.extraConfig }}
+    {{- .Values.extraConfig | toYaml | nindent 4 }}
     {{- end }}
     {{- end }}

--- a/charts/opa/values.yaml
+++ b/charts/opa/values.yaml
@@ -9,23 +9,22 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-opa:
-  logLevel: info
-  orgData:
-    enabled: true
-    bundlerSecret:
-      name: bundler
-      key: bearer-token
-  orgPolicy:
-    enabled: false
-    userinfoEndpoint: https://auth.diamond.ac.uk/cas/oidc/oidcProfile
-  configOverride: {}
-  extraConfig: {}
-  extraServices: {}
-  extraBundles: {}
-  envOverride: []
-  extraEnv: []
-  portOverride: ""
+logLevel: info
+orgData:
+  enabled: true
+  bundlerSecret:
+    name: bundler
+    key: bearer-token
+orgPolicy:
+  enabled: false
+  userinfoEndpoint: https://auth.diamond.ac.uk/cas/oidc/oidcProfile
+configOverride: {}
+extraConfig: {}
+extraServices: {}
+extraBundles: {}
+envOverride: []
+extraEnv: []
+portOverride: ""
 
 serviceAccount:
   create: false

--- a/docs/how-tos/deploy-with-helm.md
+++ b/docs/how-tos/deploy-with-helm.md
@@ -87,7 +87,7 @@ Configuration for additional services and bundles can be supplied via the `opa.e
                 resource: gcr.io/diamond-pubreg/my-application/policy
                 polling:
                     min_delay_seconds: 30
-                    max_deplay_seconds: 120
+                    max_delay_seconds: 120
         extraEnv:
             - name: MY_BUNDLE_SERVER_BEARER_TOKEN 
               valueFrom:

--- a/docs/how-tos/verify-json-web-token.md
+++ b/docs/how-tos/verify-json-web-token.md
@@ -18,7 +18,7 @@ package token
 import rego.v1
 
 fetch_jwks(url) := http.send({
-    "url": jwks_url,
+    "url": url,
     "method": "GET",
     "force_cache": true,
     "force_cache_duration_seconds": 3600,


### PR DESCRIPTION
Changes:
- Flatten structure of `values.yaml` for the OPA Helm chart. This means that chart users will configure things as, for example, `opa.orgData.enabled` rather than `opa.opa.orgData.enabled`. This brings things in line with the examples in `docs/how-tos/deploy-with-helm.md`.
- Revert `opa.name` and `opa.fullname` in `charts/opa/templates/_helpers.tpl` to the defaults created by `helm create`. This changes `opa.name` from `opa-opa` to `opa` and `opa.fullname` from `release-name-opa-opa` to `release-name-opa`.
- Fix what I think are typos in `docs/how-tos/deploy-with-helm.md` and `docs/how-tos/verify-json-web-token.md`