### PR TITLE
Fix OPA deployment checksum/config annotation

### DIFF
--- a/charts/opa/Chart.yaml
+++ b/charts/opa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opa
 description: An OPA deployment to run alongside applications requiring authorization
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: 0.59.0
 maintainers:
   - name: garryod

--- a/charts/opa/templates/deployment.yaml
+++ b/charts/opa/templates/deployment.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ .Values.config | toJson | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/opa-config.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
           {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Since 134421af19ced11d49c901ed1879d7b83dff8e69, `.Values.config` in `charts/opa/templates/deployment.yaml` has evaluated to `null`. This causes the `checksum/config` annotation on the OPA deployment to not work correctly. If `values.yaml` are changed such that the output `charts/opa/templates/opa-config.yaml` is changed but `charts/opa/templates/deployment.yaml`  is not directly updated, `helm upgrade` will not cause the deployment to be updated, and OPA will not be configured as desired. An example would be adding an extra policy bundle.

This change should fix this issue by using the output value of `charts/opa/templates/opa-config.yaml` in the checksum.