### PR TITLE
Set AWS region when publishing techdocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -82,7 +82,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.TECHDOCS_S3_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TECHDOCS_S3_SECRET_ACCESS_KEY }}
-          AWS_REGION: ""
+          AWS_REGION: "eu-west-2"
 
   bundler_build:
     # Deduplicate jobs from pull requests and branch pushes within the same repo.


### PR DESCRIPTION
New versions of the NetApp S3 API require a region to be set