### PR TITLE
Add example of accessing beamline via group admin

### DIFF
--- a/policy/diamond/policy/session/session.rego
+++ b/policy/diamond/policy/session/session.rego
@@ -28,6 +28,14 @@ access_session(subject, proposal_number, visit_number) if {
 	subject_session.visit_number == visit_number
 }
 
+# Allow if on session on one of the saxs beamlines and subject has
+# saxs_admin permission
+access_session(subject, proposal_number, visit_number) if {
+    bl := beamline(proposal_number, visit_number)
+    bl in {"i22", "b21", "p38"}
+    "saxs_admin" in data.diamond.data.subjects[subject].permissions # regal ignore:external-reference
+}
+
 # Allow if on session on b07 and subject has b07_admin permission
 access_session(subject, proposal_number, visit_number) if {
 	beamline(proposal_number, visit_number) == "b07"


### PR DESCRIPTION
Not sure if this is the best approach but from looking at the data from the
bundler, some beamlines are grouped rather than having their own admin roles,
eg, i22_admin and b21_admin are not present but saxs_admin is. Presumably
em_admin and the microscopes etc are the same.

Would it be possible to include a admin_permissions list in the beamlines data
section of the bundler data to prevent all these rules having to be hardcoded?
