### PR TITLE
Add ISSUER variable to central OPA deployment

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ../policy/:/org-policy:cached,z
     environment:
       TRACING_ADDRESS: collector:4317
-      JWKS_ENDPOINT: https://authn.diamond.ac.uk/realms/master/protocol/openid-connect/certs
+      ISSUER: https://authn.diamond.ac.uk/realms/master
 
   ispyb:
     image: ghcr.io/diamondlightsource/ispyb-database:v3.0.0

--- a/charts/opa/Chart.yaml
+++ b/charts/opa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opa
 description: An OPA deployment to run alongside applications requiring authorization
 type: application
-version: 0.5.0
+version: 0.6.0
 appVersion: 0.59.0
 maintainers:
   - name: garryod

--- a/charts/opa/templates/deployment.yaml
+++ b/charts/opa/templates/deployment.yaml
@@ -60,8 +60,8 @@ spec:
                     key: {{ .Values.orgData.bundlerSecret.key }}
             {{- end -}}
             {{- if and .Values.orgPolicy.enabled .Values.orgPolicy.jwksEndpoint }}
-            - name: JWKS_ENDPOINT
-              value: {{ .Values.orgPolicy.jwksEndpoint }}
+            - name: ISSUER
+              value: {{ .Values.orgPolicy.issuer }}
             {{- end }}
             {{- if .Values.extraEnv }}
               {{- .Values.extraEnv | toYaml | nindent 12 }}

--- a/charts/opa/values.yaml
+++ b/charts/opa/values.yaml
@@ -17,7 +17,7 @@ orgData:
     key: bearer-token
 orgPolicy:
   enabled: false
-  jwksEndpoint: https://authn.diamond.ac.uk/realms/master/protocol/openid-connect/certs
+  issuer: https://authn.diamond.ac.uk/realms/master
 configOverride: {}
 extraConfig: {}
 extraServices: {}

--- a/docs/how-tos/deploy-docker-compose.md
+++ b/docs/how-tos/deploy-docker-compose.md
@@ -14,7 +14,7 @@ The example below makes use of the [Diamond Data Bundle](../references/diamond-d
 
     Local policy which may be actively developed should not be included in the configuration file, instead it should be mounted into the OPA container and included using the `--watch` argument on the command.
 
-!!! example 
+!!! example
 
     ```yaml title="opa.yml"
     services:
@@ -51,7 +51,7 @@ If using the [Diamond Data Bundle](../references/diamond-data-bundle.md) you sho
 
 ### Using the Organisational Policy
 
-If using the [Organisational Policy](../references/organisational-policy.md) you should set the `JWKS_ENDPOINT` environment variable to the KeyCloak JSON Web Key Set (JWKS) endpoint - `https://authn.diamond.ac.uk/realms/master/protocol/openid-connect/certs` - using the `environment` list.
+If using the [Organisational Policy](../references/organisational-policy.md) you should set the `ISSUER` environment variable to the KeyCloak instance - `https://authn.diamond.ac.uk/realms/master` - using the `environment` list.
 
 ### Using Local Policy
 
@@ -88,6 +88,6 @@ To utilize local policy you should mount in the policy volume and setting the `-
           - ./opa.yml:/config.yml:cached,z
           - ../policy:/policy:cached,z
         environment:
-          JWKS_ENDPOINT: https://authn.diamond.ac.uk/realms/master/protocol/openid-connect/certs
+          ISSUER: https://authn.diamond.ac.uk/realms/master
         env_file: opa.env
     ```

--- a/docs/how-tos/verify-cas-access-token.md
+++ b/docs/how-tos/verify-cas-access-token.md
@@ -8,7 +8,7 @@ It is recommended you delegate this operation to the [Organisational Policy](../
 
 ## Using Organisational Policy
 
-When loaded, you can delegate KeyCloak token verification decisions to the [Organisational Policy Bundle](../references/organisational-policy.md) by referencing the `data.diamond.policy.token.claims` variable in your policy and setting the `JWKS_ENDPOINT` environment variable to point to the KeyCloak JWKS endpoint - e.g. `https://authn.diamond.ac.uk/realms/master/protocol/openid-connect/certs`.
+When loaded, you can delegate KeyCloak token verification decisions to the [Organisational Policy Bundle](../references/organisational-policy.md) by referencing the `data.diamond.policy.token.claims` variable in your policy and setting the `ISSUER` environment variable to point to the KeyCloak instance - e.g. `https://authn.diamond.ac.uk/realms/master`.
 
 The example below shows how you might write a system package which allows the action if `input.action` is "do_thing" and the `input.token` is for the subject "bob".
 

--- a/policy/diamond/policy/token/token.rego
+++ b/policy/diamond/policy/token/token.rego
@@ -2,16 +2,24 @@ package diamond.policy.token
 
 import rego.v1
 
+issuer := opa.runtime().env.ISSUER
+
+jwks_endpoint := jwks_endpoint if {
+	metadata := http.send({
+		"url": concat("", [issuer, "/.well-known/openid-configuration"]),
+		"method": "GET",
+		"force_cache": true,
+		"force_cache_duration_seconds": 86400,
+	}).body
+	jwks_endpoint := metadata.jwks_uri
+}
+
 fetch_jwks(url) := http.send({
 	"url": url,
 	"method": "GET",
 	"force_cache": true,
 	"force_cache_duration_seconds": 86400,
 })
-
-jwks_endpoint := opa.runtime().env.JWKS_ENDPOINT
-
-issuer := opa.runtime().env.ISSUER
 
 unverified := io.jwt.decode(input.token)
 


### PR DESCRIPTION
Only remembered we'd added this to the token validation after the other PR was merged. Not sure what the issuer  value should be so I opted for the value used in the docs/examples.