### PR TITLE
Bump app versions to 0.0.14

### DIFF
--- a/charts/bundler/Chart.yaml
+++ b/charts/bundler/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: bundler
 description: A Open Policy Agent (OPA) Data Bundle Server providing permissionable data from ISPyB
 type: application
-version: 0.5.0
-appVersion: 0.0.13
+version: 0.5.1
+appVersion: 0.0.14
 maintainers:
   - name: garryod
     email: "garry.o'donnell@diamond.ac.uk"

--- a/charts/opa/Chart.yaml
+++ b/charts/opa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opa
 description: An OPA deployment to run alongside applications requiring authorization
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.59.0
 maintainers:
   - name: garryod

--- a/charts/opa/templates/opa-config.yaml
+++ b/charts/opa/templates/opa-config.yaml
@@ -32,7 +32,7 @@ data:
       {{- if .Values.orgPolicy.enabled }}
       diamond-policies:
         service: ghcr
-        resource: ghcr.io/diamondlightsource/authz-policy:0.0.13
+        resource: ghcr.io/diamondlightsource/authz-policy:0.0.14
         polling:
           min_delay_seconds: 30
           max_delay_seconds: 120


### PR DESCRIPTION
Is there anything else required to update the policy being used beyond updating
the versions here, then creating a new tag/release?
