### PR TITLE
ci: add commitlint to enforce conventional commits

### DIFF
--- a/.github/workflows/_commit_lint.yaml
+++ b/.github/workflows/_commit_lint.yaml
@@ -1,0 +1,21 @@
+name: Lint Commits
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Lint Commits
+        uses: wagoid/commitlint-github-action@v6.1.2
+        with:
+          failOnWarnings: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,14 @@ on:
   pull_request:
 
 jobs:
+  commit_lint:
+    # Deduplicate jobs from pull requests and branch pushes within the same repo.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: ./.github/workflows/_commit_lint.yaml
+
   devcontainer:
     # Deduplicate jobs from pull requests and branch pushes within the same repo.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository


### PR DESCRIPTION
Requires #230 

Adds [commitlint](https://commitlint.js.org/) to CI in order to ensure commits messages conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). This is necessary prerequisite for using [release please](https://github.com/googleapis/release-please)