### PR TITLE
Fix techdocs publishing by passing secrets

### DIFF
--- a/.github/workflows/_techdocs_publish.yaml
+++ b/.github/workflows/_techdocs_publish.yaml
@@ -2,6 +2,11 @@ name: Techdocs Publish
 
 on:
   workflow_call:
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
 
 jobs:
   publish:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,6 +95,9 @@ jobs:
     needs:
       - docs_lint
       - docs_build
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.TECHDOCS_S3_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.TECHDOCS_S3_SECRET_ACCESS_KEY }}
     uses: ./.github/workflows/_techdocs_publish.yaml
   
   pages_build:


### PR DESCRIPTION
I missed the fact that by making `_techdocs_publish` a re-usable workflow secrets would not be passed automatically - and testing was skipped on the PR because the step is only run on `main`. This PR fixes this by passing the secrets to the re-usable workflow explicitly