### PR TITLE
Disable `commitlint` max line body line length commit to allow dependabot commits

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,5 +1,11 @@
 {
   "extends": [
     "@commitlint/config-conventional"
-  ]
+  ],
+  "rules": {
+    "body-max-line-length": [
+      0,
+      "always"
+    ]
+  }
 }

--- a/.github/workflows/_commit_lint.yaml
+++ b/.github/workflows/_commit_lint.yaml
@@ -18,4 +18,5 @@ jobs:
       - name: Lint Commits
         uses: wagoid/commitlint-github-action@v6.1.2
         with:
+          configFile: .commitlintrc.json
           failOnWarnings: true


### PR DESCRIPTION
The commits generated by dependabot unfortunately contain rather long lines due to the inclusion of changelog URLs, these are not configurable and exceed the max line body length configured by `@commitlint/config-conventional`. This PR disables this lint as a temporary fix