### PR TITLE
Increase OPA resource requests to prevent erroneous autoscaling during startup

### DIFF
--- a/charts/opa/Chart.yaml
+++ b/charts/opa/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opa
 description: An OPA deployment to run alongside applications requiring authorization
 type: application
-version: 0.6.3
+version: 0.6.4
 appVersion: 0.59.0
 maintainers:
   - name: garryod

--- a/charts/opa/values.yaml
+++ b/charts/opa/values.yaml
@@ -47,7 +47,13 @@ ingress:
   hosts: []
   tls: []
 
-resources: {}
+resources:
+  requests:
+    cpu: 1000m
+    memory: 2Gi
+  limits:
+    cpu: 1000m
+    memory: 2Gi
 
 replicaCount: 1
 


### PR DESCRIPTION
Due to low default CPU requests, the Horizontal Pod Autoscaler (HPA) is erroneously increasing the replica count in response to OPA unpacking the bundle