### PR TITLE
Make bundler binary auditable

### DIFF
--- a/bundler/Dockerfile
+++ b/bundler/Dockerfile
@@ -2,6 +2,8 @@ FROM docker.io/library/rust:1.84.0-bookworm AS build
 
 ARG DATABASE_URL
 
+RUN cargo install cargo-auditable
+
 WORKDIR /app
 
 RUN cargo init
@@ -10,7 +12,7 @@ RUN cargo build --release
 
 COPY ./ ./
 RUN touch src/main.rs \
-    && cargo build --release
+    && cargo auditable build --release
 
 FROM gcr.io/distroless/cc-debian12@sha256:f913198471738d9eedcd00c0ca812bf663e8959eebff3a3cbadb027ed9da0c38 AS deploy
 


### PR DESCRIPTION
Uses [`cargo-auditable`](https://github.com/rust-secure-code/cargo-auditable) to build the bundler binary in the `Dockerfile`, this allows scanners such as trivy (used by stackrox) to interrogate the binary for dependencies and audit them