### PR TITLE
feat: blueapi policy

### DIFF
--- a/.github/workflows/_policy_lint.yaml
+++ b/.github/workflows/_policy_lint.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Regal
-        uses: StyraInc/setup-regal@v1.0.0
+        uses: open-policy-agent/setup-regal@v2.0.0
         with:
           version: latest
 

--- a/policy/diamond/policy/blueapi/blueapi.rego
+++ b/policy/diamond/policy/blueapi/blueapi.rego
@@ -1,6 +1,9 @@
 package diamond.policy.blueapi
 
+import data.diamond.policy.admin
+import data.diamond.policy.session
 import data.diamond.policy.token
+
 import rego.v1
 
 default tiled_service_account_for_beamline := false
@@ -9,4 +12,52 @@ tiled_service_account_for_beamline if {
 	input.beamline == token.claims.beamline
 	"tiled-writer" in token.claims.aud
 	not token.claims.fedid
+}
+
+_session := data.diamond.data.proposals[format_int(input.proposal, 10)].sessions[format_int(input.visit, 10)]
+
+# Returns the session ID if the subject has write permissions for the
+# specific beamline, visit and proposal requested in the input.
+user_session := format_int(_session, 10) if {
+	session.write_to_beamline_visit
+	_session
+}
+
+# Check if user should be able to submit tasks only if they're on
+# the same instrument as the instrument session in question.
+
+default post_task := false
+
+post_task if {
+	session.write_to_beamline_visit
+}
+
+default delete_task := false
+
+delete_task if {
+	input.user == token.claims.fedid
+}
+
+delete_task if {
+	admin.is_admin(token.claims.fedid)
+}
+
+default fetch_task := false
+
+fetch_task if {
+	input.user == token.claims.fedid
+}
+
+fetch_task if {
+	admin.is_admin(token.claims.fedid)
+}
+
+default put_worker_state_abort := false
+
+put_worker_state_abort if {
+	input.user == token.claims.fedid
+}
+
+put_worker_state_abort if {
+	admin.is_admin(token.claims.fedid)
 }

--- a/policy/diamond/policy/blueapi/blueapi.rego
+++ b/policy/diamond/policy/blueapi/blueapi.rego
@@ -14,50 +14,14 @@ tiled_service_account_for_beamline if {
 	not token.claims.fedid
 }
 
-_session := data.diamond.data.proposals[format_int(input.proposal, 10)].sessions[format_int(input.visit, 10)]
+default write_to_beamline_visit := false
 
-# Returns the session ID if the subject has write permissions for the
-# specific beamline, visit and proposal requested in the input.
-user_session := format_int(_session, 10) if {
-	session.write_to_beamline_visit
-	_session
-}
-
-# Check if user should be able to submit tasks only if they're on
-# the same instrument as the instrument session in question.
-
-default post_task := false
-
-post_task if {
+write_to_beamline_visit if {
 	session.write_to_beamline_visit
 }
 
-default delete_task := false
-
-delete_task if {
-	input.user == token.claims.fedid
-}
-
-delete_task if {
-	admin.is_admin(token.claims.fedid)
-}
-
-default fetch_task := false
-
-fetch_task if {
-	input.user == token.claims.fedid
-}
-
-fetch_task if {
-	admin.is_admin(token.claims.fedid)
-}
-
-default put_worker_state_abort := false
-
-put_worker_state_abort if {
-	input.user == token.claims.fedid
-}
-
-put_worker_state_abort if {
-	admin.is_admin(token.claims.fedid)
+# Service account check
+write_to_beamline_visit if {
+	input.beamline == token.claims.beamline
+	input.beamline == session.beamline
 }

--- a/policy/diamond/policy/blueapi/blueapi_test.rego
+++ b/policy/diamond/policy/blueapi/blueapi_test.rego
@@ -3,6 +3,49 @@ package diamond.policy.blueapi_test
 import data.diamond.policy.blueapi
 import rego.v1
 
+diamond_data := {
+	"subjects": {
+		"alice": {
+			"permissions": [],
+			"proposals": [1],
+			"sessions": [],
+		},
+		"bob": {
+			"permissions": ["b07_admin"],
+			"proposals": [],
+			"sessions": [11],
+		},
+		"carol": {
+			"permissions": ["super_admin"],
+			"proposals": [],
+			"sessions": [],
+		},
+		"oscar": {
+			"permissions": [],
+			"proposals": [],
+			"sessions": [],
+		},
+	},
+	"sessions": {
+		"11": {
+			"beamline": "i03",
+			"proposal_number": 1,
+			"visit_number": 1,
+		},
+		"12": {
+			"beamline": "b07",
+			"proposal_number": 1,
+			"visit_number": 2,
+		},
+	},
+	"proposals": {"1": {"sessions": {
+		"1": 11,
+		"2": 12,
+	}}},
+	"beamlines": {"i03": {"sessions": [11]}, "b07": {"sessions": [12]}},
+	"admin": {"b07_admin": ["b07"]},
+}
+
 test_service_account_if_beamline_matches if {
 	blueapi.tiled_service_account_for_beamline with input as {"beamline": "i22"}
 		with data.diamond.policy.token.claims as {"beamline": "i22", "aud": ["tiled-writer"]}
@@ -21,4 +64,107 @@ test_not_service_account_if_missing_aud if {
 test_not_service_account_if_fedid_present if {
 	not blueapi.tiled_service_account_for_beamline with input as {"beamline": "i22"}
 		with data.diamond.policy.token.claims as {"beamline": "i22", "aud": ["tiled-writer"], "fedid": "abc12345"}
+}
+
+test_user_session_not_allowed if {
+	not blueapi.user_session with data.diamond.data as diamond_data
+		with input as {"proposal": 1, "visit": 1, "beamline": "i03"}
+		with data.diamond.policy.token.claims as {"fedid": "oscar"}
+}
+
+test_user_session_allow if {
+	blueapi.user_session with data.diamond.data as diamond_data
+		with input as {"proposal": 1, "visit": 1, "beamline": "i03"}
+		with data.diamond.policy.token.claims as {"fedid": "bob"}
+}
+
+# b07_admin user can access a b07 session via their role, not direct session membership
+test_user_session_allow_for_beamline_admin_via_role if {
+	blueapi.user_session with data.diamond.data as diamond_data
+		with input as {"proposal": 1, "visit": 2, "beamline": "b07"}
+		with data.diamond.policy.token.claims as {"fedid": "bob"}
+}
+
+# Instrument session has to match instrument of blueapi instance test
+test_user_session_not_allowed_if_instrument_session_doesnt_match_blueapi_instance if {
+	not blueapi.user_session with data.diamond.data as diamond_data
+		with input as {"proposal": 1, "visit": 1, "beamline": "b07"}
+		with data.diamond.policy.token.claims as {"fedid": "bob"}
+}
+
+# POST /tasks denied if user not on instrument session test
+test_post_tasks_not_allowed_if_user_not_on_instrument_session if {
+	not blueapi.post_task with data.diamond.data as diamond_data
+		with input as {"proposal": 1, "visit": 1, "beamline": "i03"}
+		with data.diamond.policy.token.claims as {"fedid": "oscar"}
+}
+
+# POST /tasks allowed if user on instrument session test
+test_post_tasks_allowed_if_user_on_instrument_session if {
+	blueapi.post_task with data.diamond.data as diamond_data
+		with input as {"proposal": 1, "visit": 1, "beamline": "i03"}
+		with data.diamond.policy.token.claims as {"fedid": "bob"}
+}
+
+# DELETE /task denied if fed_id doesn't match task owner test
+test_delete_task_not_allowed_if_fed_id_doesnt_match_task_owner if {
+	not blueapi.delete_task with data.diamond.data as diamond_data
+		with input as {"user": "alice"}
+		with data.diamond.policy.token.claims as {"fedid": "oscar"}
+}
+
+# DELETE /task allowed if fed_id matches task owner test
+test_delete_task_allowed_if_fed_id_matches_task_owner if {
+	blueapi.delete_task with data.diamond.data as diamond_data
+		with input as {"user": "alice"}
+		with data.diamond.policy.token.claims as {"fedid": "alice"}
+}
+
+# GET task/{task_id} denied if task not submitted by requesting user test
+test_get_task_not_allowed_if_task_not_submitted_by_requesting_user if {
+	not blueapi.fetch_task with data.diamond.data as diamond_data
+		with input as {"user": "alice"}
+		with data.diamond.policy.token.claims as {"fedid": "oscar"}
+}
+
+# GET task/{task_id} allowed if task submitted by requesting user test
+test_get_task_allowed_if_task_submitted_by_requesting_user if {
+	blueapi.fetch_task with data.diamond.data as diamond_data
+		with input as {"user": "oscar"}
+		with data.diamond.policy.token.claims as {"fedid": "oscar"}
+}
+
+# PUT /worker/state abort denied if not task creator test
+test_put_worker_state_abort_not_allowed_if_not_task_creator if {
+	not blueapi.put_worker_state_abort with data.diamond.data as diamond_data
+		with input as {"user": "alice"}
+		with data.diamond.policy.token.claims as {"fedid": "oscar"}
+}
+
+# PUT /worker/state abort allowed if task creator test
+test_put_worker_state_abort_allowed_if_task_creator if {
+	blueapi.put_worker_state_abort with data.diamond.data as diamond_data
+		with input as {"user": "alice"}
+		with data.diamond.policy.token.claims as {"fedid": "alice"}
+}
+
+# DELETE /task allowed for admin regardless of task ownership
+test_delete_task_allowed_for_admin if {
+	blueapi.delete_task with data.diamond.data as diamond_data
+		with input as {"user": "alice"}
+		with data.diamond.policy.token.claims as {"fedid": "carol"}
+}
+
+# GET /task/{task_id} allowed for admin regardless of task ownership
+test_get_task_allowed_for_admin if {
+	blueapi.fetch_task with data.diamond.data as diamond_data
+		with input as {"user": "alice"}
+		with data.diamond.policy.token.claims as {"fedid": "carol"}
+}
+
+# PUT /worker/state abort allowed for admin regardless of task ownership
+test_put_worker_state_abort_allowed_for_admin if {
+	blueapi.put_worker_state_abort with data.diamond.data as diamond_data
+		with input as {"user": "alice"}
+		with data.diamond.policy.token.claims as {"fedid": "carol"}
 }

--- a/policy/diamond/policy/blueapi/blueapi_test.rego
+++ b/policy/diamond/policy/blueapi/blueapi_test.rego
@@ -20,6 +20,16 @@ diamond_data := {
 			"proposals": [],
 			"sessions": [],
 		},
+		"desmond": {
+			"permissions": [],
+			"proposals": [2],
+			"sessions": [13],
+		},
+		"edna": {
+			"permissions": [],
+			"proposals": [2],
+			"sessions": [13, 14],
+		},
 		"oscar": {
 			"permissions": [],
 			"proposals": [],
@@ -37,12 +47,28 @@ diamond_data := {
 			"proposal_number": 1,
 			"visit_number": 2,
 		},
+		"13": {
+			"beamline": "b07",
+			"proposal_number": 2,
+			"visit_number": 1,
+		},
+		"14": {
+			"beamline": "b07",
+			"proposal_number": 2,
+			"visit_number": 2,
+		},
 	},
-	"proposals": {"1": {"sessions": {
-		"1": 11,
-		"2": 12,
-	}}},
-	"beamlines": {"i03": {"sessions": [11]}, "b07": {"sessions": [12]}},
+	"proposals": {
+		"1": {"sessions": {
+			"1": 11,
+			"2": 12,
+		}},
+		"2": {"sessions": {
+			"1": 13,
+			"2": 14,
+		}},
+	},
+	"beamlines": {"i03": {"sessions": [11]}, "b07": {"sessions": [12, 13, 14]}},
 	"admin": {"b07_admin": ["b07"]},
 }
 
@@ -66,105 +92,22 @@ test_not_service_account_if_fedid_present if {
 		with data.diamond.policy.token.claims as {"beamline": "i22", "aud": ["tiled-writer"], "fedid": "abc12345"}
 }
 
-test_user_session_not_allowed if {
-	not blueapi.user_session with data.diamond.data as diamond_data
-		with input as {"proposal": 1, "visit": 1, "beamline": "i03"}
-		with data.diamond.policy.token.claims as {"fedid": "oscar"}
+# service account UDC path
+
+test_write_to_beamline_visit_service_account if {
+	blueapi.write_to_beamline_visit with data.diamond.data as diamond_data
+		with input as {"beamline": "i03", "proposal": 1, "visit": 1}
+		with data.diamond.policy.token.claims as {"beamline": "i03"}
 }
 
-test_user_session_allow if {
-	blueapi.user_session with data.diamond.data as diamond_data
-		with input as {"proposal": 1, "visit": 1, "beamline": "i03"}
-		with data.diamond.policy.token.claims as {"fedid": "bob"}
+test_write_to_beamline_visit_service_account_wrong_beamline if {
+	not blueapi.write_to_beamline_visit with data.diamond.data as diamond_data
+		with input as {"beamline": "i03", "proposal": 1, "visit": 1}
+		with data.diamond.policy.token.claims as {"beamline": "b07"}
 }
 
-# b07_admin user can access a b07 session via their role, not direct session membership
-test_user_session_allow_for_beamline_admin_via_role if {
-	blueapi.user_session with data.diamond.data as diamond_data
-		with input as {"proposal": 1, "visit": 2, "beamline": "b07"}
-		with data.diamond.policy.token.claims as {"fedid": "bob"}
-}
-
-# Instrument session has to match instrument of blueapi instance test
-test_user_session_not_allowed_if_instrument_session_doesnt_match_blueapi_instance if {
-	not blueapi.user_session with data.diamond.data as diamond_data
-		with input as {"proposal": 1, "visit": 1, "beamline": "b07"}
-		with data.diamond.policy.token.claims as {"fedid": "bob"}
-}
-
-# POST /tasks denied if user not on instrument session test
-test_post_tasks_not_allowed_if_user_not_on_instrument_session if {
-	not blueapi.post_task with data.diamond.data as diamond_data
-		with input as {"proposal": 1, "visit": 1, "beamline": "i03"}
-		with data.diamond.policy.token.claims as {"fedid": "oscar"}
-}
-
-# POST /tasks allowed if user on instrument session test
-test_post_tasks_allowed_if_user_on_instrument_session if {
-	blueapi.post_task with data.diamond.data as diamond_data
-		with input as {"proposal": 1, "visit": 1, "beamline": "i03"}
-		with data.diamond.policy.token.claims as {"fedid": "bob"}
-}
-
-# DELETE /task denied if fed_id doesn't match task owner test
-test_delete_task_not_allowed_if_fed_id_doesnt_match_task_owner if {
-	not blueapi.delete_task with data.diamond.data as diamond_data
-		with input as {"user": "alice"}
-		with data.diamond.policy.token.claims as {"fedid": "oscar"}
-}
-
-# DELETE /task allowed if fed_id matches task owner test
-test_delete_task_allowed_if_fed_id_matches_task_owner if {
-	blueapi.delete_task with data.diamond.data as diamond_data
-		with input as {"user": "alice"}
-		with data.diamond.policy.token.claims as {"fedid": "alice"}
-}
-
-# GET task/{task_id} denied if task not submitted by requesting user test
-test_get_task_not_allowed_if_task_not_submitted_by_requesting_user if {
-	not blueapi.fetch_task with data.diamond.data as diamond_data
-		with input as {"user": "alice"}
-		with data.diamond.policy.token.claims as {"fedid": "oscar"}
-}
-
-# GET task/{task_id} allowed if task submitted by requesting user test
-test_get_task_allowed_if_task_submitted_by_requesting_user if {
-	blueapi.fetch_task with data.diamond.data as diamond_data
-		with input as {"user": "oscar"}
-		with data.diamond.policy.token.claims as {"fedid": "oscar"}
-}
-
-# PUT /worker/state abort denied if not task creator test
-test_put_worker_state_abort_not_allowed_if_not_task_creator if {
-	not blueapi.put_worker_state_abort with data.diamond.data as diamond_data
-		with input as {"user": "alice"}
-		with data.diamond.policy.token.claims as {"fedid": "oscar"}
-}
-
-# PUT /worker/state abort allowed if task creator test
-test_put_worker_state_abort_allowed_if_task_creator if {
-	blueapi.put_worker_state_abort with data.diamond.data as diamond_data
-		with input as {"user": "alice"}
-		with data.diamond.policy.token.claims as {"fedid": "alice"}
-}
-
-# DELETE /task allowed for admin regardless of task ownership
-test_delete_task_allowed_for_admin if {
-	blueapi.delete_task with data.diamond.data as diamond_data
-		with input as {"user": "alice"}
-		with data.diamond.policy.token.claims as {"fedid": "carol"}
-}
-
-# GET /task/{task_id} allowed for admin regardless of task ownership
-test_get_task_allowed_for_admin if {
-	blueapi.fetch_task with data.diamond.data as diamond_data
-		with input as {"user": "alice"}
-		with data.diamond.policy.token.claims as {"fedid": "carol"}
-}
-
-# PUT /worker/state abort allowed for admin regardless of task ownership
-test_put_worker_state_abort_allowed_for_admin if {
-	blueapi.put_worker_state_abort with data.diamond.data as diamond_data
-		with input as {"user": "alice"}
-		with data.diamond.policy.token.claims as {"fedid": "carol"}
+test_write_to_beamline_visit_service_account_nonexistent_beamline if {
+	not blueapi.write_to_beamline_visit with data.diamond.data as diamond_data
+		with input as {"beamline": "i03", "proposal": 1, "visit": 1}
+		with data.diamond.policy.token.claims as {"beamline": "i99"}
 }


### PR DESCRIPTION
[Jira ticket](https://jira.diamond.ac.uk/browse/ACQP-542)

Adds Rego policy for blueapi task submission and querying.

task ownership (delete,query,about) by comparing "user" in the meta against fedid

