### PR TITLE
refactor: fix regal lint issues

### DIFF
--- a/policy/diamond/policy/admin/admin_test.rego
+++ b/policy/diamond/policy/admin/admin_test.rego
@@ -71,12 +71,10 @@ test_admin_rule_for_non_admin if {
 }
 
 # If no user is passed as input, the rule should be undefined
-test_admin_rule_for_no_user := false if {
-	local_admin := admin.admin with data.diamond.policy.token.claims as {}
+test_admin_rule_for_no_user if {
+	not admin.admin with data.diamond.policy.token.claims as {}
 		with data.diamond.data as diamond_data
 }
-
-else := true # regal ignore:default-over-else
 
 test_beamline_admin_rule_for_beamline_admin if {
 	admin.beamline_admin with input as {"beamline": "b07"}
@@ -104,23 +102,17 @@ test_beamline_admin_rule_for_wrong_beamline_admin if {
 		with data.diamond.data as diamond_data
 }
 
-test_beamline_admin_rule_for_no_user := false if {
-	local_admin := admin.beamline_admin with input as {"beamline": "i07"}
+test_beamline_admin_rule_for_no_user if {
+	not admin.beamline_admin with input as {"beamline": "i07"}
 		with data.diamond.data as diamond_data
 }
 
-else := true # regal ignore:default-over-else
-
-test_beamline_admin_rule_for_no_beamline := false if {
-	local_admin := admin.beamline_admin with data.diamond.policy.token.claims as {"fedid": "bob"}
+test_beamline_admin_rule_for_no_beamline if {
+	not admin.beamline_admin with data.diamond.policy.token.claims as {"fedid": "bob"}
 		with data.diamond.data as diamond_data
 }
 
-else := true # regal ignore:default-over-else
-
-test_beamline_admin_rule_for_no_input := false if {
-	local_admin := admin.beamline_admin with input as {}
+test_beamline_admin_rule_for_no_input if {
+	not admin.beamline_admin with input as {}
 		with data.diamond.data as diamond_data
 }
-
-else := true # regal ignore:default-over-else

--- a/policy/diamond/policy/proposal/proposal.rego
+++ b/policy/diamond/policy/proposal/proposal.rego
@@ -7,13 +7,13 @@ import rego.v1
 default on_proposal(_, _) := false
 
 on_proposal(subject, proposal_number) if {
-	proposal_number in data.diamond.data.subjects[subject].proposals # regal ignore:external-reference
+	proposal_number in data.diamond.data.subjects[subject].proposals
 }
 
 default access_proposal(_, _) := false
 
 # Allow if subject has super_admin permission
-access_proposal(subject, proposal_number) if admin.is_admin(subject) # regal ignore:external-reference
+access_proposal(subject, _) if admin.is_admin(subject)
 
 # Allow if subject is on proposal
 access_proposal(subject, proposal_number) if on_proposal(subject, proposal_number)

--- a/policy/diamond/policy/proposal/proposal_test.rego
+++ b/policy/diamond/policy/proposal/proposal_test.rego
@@ -56,19 +56,15 @@ test_named_user_rule_for_unnamed_user if {
 		with data.diamond.data as diamond_data
 }
 
-test_named_user_rule_for_no_user := false if {
-	named := proposal.named_user with input as {"proposal": 1}
+test_named_user_rule_for_no_user if {
+	not proposal.named_user with input as {"proposal": 1}
 		with data.diamond.data as diamond_data
 }
 
-else := true # regal ignore:default-over-else
-
-test_named_user_rule_for_no_proposal := false if {
-	named := proposal.named_user with data.diamond.policy.token.claims as {"fedid": "carol"}
+test_named_user_rule_for_no_proposal if {
+	not proposal.named_user with data.diamond.policy.token.claims as {"fedid": "carol"}
 		with data.diamond.data as diamond_data
 }
-
-else := true # regal ignore:default-over-else
 
 test_access_rule_for_super_admin if {
 	proposal.access with input as {"proposal": 1}
@@ -88,16 +84,12 @@ test_access_rule_for_unnamed_user if {
 		with data.diamond.data as diamond_data
 }
 
-test_access_rule_for_no_user := false if {
-	access := proposal.access with input as {"proposal": 1}
+test_access_rule_for_no_user if {
+	not proposal.access with input as {"proposal": 1}
 		with data.diamond.data as diamond_data
 }
 
-else := true # regal ignore:default-over-else
-
-test_access_rule_for_no_proposal := false if {
-	access := proposal.access with data.diamond.policy.token.claims as {"fedid": "alice"}
+test_access_rule_for_no_proposal if {
+	not proposal.access with data.diamond.policy.token.claims as {"fedid": "alice"}
 		with data.diamond.data as diamond_data
 }
-
-else := true # regal ignore:default-over-else

--- a/policy/diamond/policy/session/session.rego
+++ b/policy/diamond/policy/session/session.rego
@@ -6,17 +6,17 @@ import data.diamond.policy.token
 import rego.v1
 
 beamline_for(proposal_number, visit_number) := beamline if {
-	proposal := data.diamond.data.proposals[format_int(proposal_number, 10)] # regal ignore:external-reference
+	proposal := data.diamond.data.proposals[format_int(proposal_number, 10)]
 	session_id := proposal.sessions[format_int(visit_number, 10)]
-	session := data.diamond.data.sessions[format_int(session_id, 10)] # regal ignore:external-reference
+	session := data.diamond.data.sessions[format_int(session_id, 10)]
 	beamline := session.beamline
 }
 
 default on_session(_, _, _) := false
 
 on_session(subject, proposal_number, visit_number) if {
-	some session_id in data.diamond.data.subjects[subject].sessions # regal ignore:external-reference
-	subject_session := data.diamond.data.sessions[format_int(session_id, 10)] # regal ignore:external-reference
+	some session_id in data.diamond.data.subjects[subject].sessions
+	subject_session := data.diamond.data.sessions[format_int(session_id, 10)]
 	subject_session.proposal_number == proposal_number
 	subject_session.visit_number == visit_number
 }
@@ -24,16 +24,15 @@ on_session(subject, proposal_number, visit_number) if {
 default access_session(_, _, _) := false
 
 # Allow if subject has super_admin permission
-access_session(subject, proposal_number, visit_number) if admin.is_admin(subject) # regal ignore:external-reference
+access_session(subject, _, _) if admin.is_admin(subject)
 
 # Allow if subject is admin for beamline containing session
 access_session(subject, proposal_number, visit_number) if {
-	# regal ignore:external-reference
 	beamline_for(proposal_number, visit_number) in admin.beamline_admin_for_subject[subject]
 }
 
 # Allow if subject on proposal which contains session
-access_session(subject, proposal_number, visit_number) if proposal.on_proposal(subject, proposal_number)
+access_session(subject, proposal_number, _) if proposal.on_proposal(subject, proposal_number)
 
 # Allow if subject directly on session
 access_session(subject, proposal_number, visit_number) if on_session(subject, proposal_number, visit_number)
@@ -46,12 +45,10 @@ named_user := on_session(token.claims.fedid, input.proposal, input.visit)
 
 beamline := beamline_for(input.proposal, input.visit)
 
-matches_beamline := input.beamline == beamline # regal ignore:boolean-assignment
-
 # A user can only write to a visit if the given user, beamline and visit are all compatible
 default write_to_beamline_visit := false
 
 write_to_beamline_visit if {
 	access
-	matches_beamline
+	input.beamline == beamline
 }

--- a/policy/diamond/policy/session/session_test.rego
+++ b/policy/diamond/policy/session/session_test.rego
@@ -94,28 +94,22 @@ test_access_rule_for_non_user if {
 		with data.diamond.data as diamond_data
 }
 
-test_access_rule_for_no_user := false if {
-	access := session.access with input as {"proposal": 1, "visit": 2}
+test_access_rule_for_no_user if {
+	not session.access with input as {"proposal": 1, "visit": 2}
 		with data.diamond.data as diamond_data
 }
 
-else := true # regal ignore:default-over-else
-
-test_access_rule_for_no_proposal := false if {
-	access := session.access with input as {"visit": 2}
+test_access_rule_for_no_proposal if {
+	not session.access with input as {"visit": 2}
 		with data.diamond.policy.token.claims as {"fedid": "bob"}
 		with data.diamond.data as diamond_data
 }
 
-else := true # regal ignore:default-over-else
-
-test_access_rule_for_no_visit := false if {
-	access := session.access with input as {"proposal": 2}
+test_access_rule_for_no_visit if {
+	not session.access with input as {"proposal": 2}
 		with data.diamond.policy.token.claims as {"fedid": "bob"}
 		with data.diamond.data as diamond_data
 }
-
-else := true # regal ignore:default-over-else
 
 test_named_user_rule_for_named_user if {
 	session.named_user with input as {"proposal": 1, "visit": 1}
@@ -148,29 +142,29 @@ test_named_user_rule_for_named_proposal if {
 		with data.diamond.data as diamond_data
 }
 
-test_matches_beamline_rule_for_match if {
-	session.matches_beamline with input as {"beamline": "b07", "proposal": 1, "visit": 2}
+test_write_to_beamline_rule_for_match if {
+	session.write_to_beamline_visit with input as {"beamline": "b07", "proposal": 1, "visit": 2}
+		with data.diamond.policy.token.claims as {"fedid": "bob"}
 		with data.diamond.data as diamond_data
 }
 
-test_matches_beamline_rule_for_non_match if {
-	not session.matches_beamline with input as {"beamline": "b07", "proposal": 1, "visit": 1}
+test_write_to_beamline_rule_for_non_match if {
+	not session.write_to_beamline_visit with input as {"beamline": "b07", "proposal": 1, "visit": 1}
+		with data.diamond.policy.token.claims as {"fedid": "alice"}
 		with data.diamond.data as diamond_data
 }
 
-test_matches_beamline_rule_for_no_beamline := false if {
-	match := session.matches_beamline with input as {"proposal": 1, "visit": 1}
+test_write_to_beamline_rule_for_no_beamline if {
+	not session.write_to_beamline_visit with input as {"proposal": 1, "visit": 1}
+		with data.diamond.policy.token.claims as {"fedid": "alice"}
 		with data.diamond.data as diamond_data
 }
 
-else := true # regal ignore:default-over-else
-
-test_matches_beamline_rule_for_no_visit := false if {
-	match := session.matches_beamline with input as {"beamline": "b07"}
+test_write_to_beamline_rule_for_no_visit if {
+	not session.write_to_beamline_visit with input as {"beamline": "b07"}
+		with data.diamond.policy.token.claims as {"fedid": "alice"}
 		with data.diamond.data as diamond_data
 }
-
-else := true # regal ignore:default-over-else
 
 test_session_beamline if {
 	bl1 := session.beamline with input as {"proposal": 1, "visit": 1}


### PR DESCRIPTION
Fix regal lints :- 

- regal ignore:default-over-else
- regal ignore:external-reference as we have a ignore at the root
- regal ignore:boolean-assignment
- Use underscore when variable not used internally 
example: access_proposal(subject, _) if admin.is_admin(subject)