### PR TITLE
ci: Update versions of node and use setup-regal

### DIFF
--- a/.github/workflows/_docs_lint.yaml
+++ b/.github/workflows/_docs_lint.yaml
@@ -8,17 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4.2.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install Yarn dependencies
-        uses: borales/actions-yarn@v5.0.0
-        with:
-          cmd: global add markdownlint-cli2 markdown-it-admon
+        run: yarn global add markdownlint-cli2 markdown-it-admon
 
       - name: Lint with markdownlint-cli2
         run: >

--- a/.github/workflows/_policy_lint.yaml
+++ b/.github/workflows/_policy_lint.yaml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Setup Regal
-        uses: StyraInc/setup-regal@v1.0.0
+        uses: open-policy-agent/setup-regal@761188c3b435761fa254beca508a44875619648f #v2.0.0
         with:
           version: latest
 


### PR DESCRIPTION
`StyraInc/setup-regal@v1.0.0` has been removed and moved to [opa](https://github.com/open-policy-agent/setup-regal/pull/8/changes) 

Node 20 has also been deprecated in CI so just updating the version to Node 24 